### PR TITLE
Reverted footer change from 2023 back to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2023 XYZ, Inc._
+_© 2022 XYZ, Inc._


### PR DESCRIPTION
This pull request reverts the previous change made to the README.md footer.

Before: 2023 XYZ, Inc.

After: 2022 XYZ, Inc.

The change was reverted using the git revert command to restore the original footer text.